### PR TITLE
Update doh-proxy to version 0.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM rust:latest as cargo-build
 
-ARG VERSION=0.1.19
+ARG VERSION=0.3.3
 
 RUN apt-get update
 
@@ -18,7 +18,7 @@ RUN RUSTFLAGS=-Clinker=musl-gcc cargo install doh-proxy --version $VERSION --roo
 # Final Stage
 # ------------------------------------------------------------------------------
 
-FROM alpine:3.10
+FROM alpine:3.12
 
 RUN apk add --no-cache libgcc runit shadow curl
 


### PR DESCRIPTION
Nothing crazy. I just noticed this image (thanks!) and the fact that the `doh-proxy` version was a little bit dated, so here is a straightforward update.

Thanks!